### PR TITLE
Resolve Missing Export Condition Error in Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,4 +40,8 @@
 		"vitest": "^0.25.3"
 	},
 	"type": "module"
+	"exports": {
+		".": {
+			"svelte": "./index.js"
+		}
 }


### PR DESCRIPTION
To address the Missing Export Condition Error resulting from Vite's planned deprecation of unsupported features, I propose the following fix. 

For more details on the issue and resolution, please refer to the [documentation](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition).

